### PR TITLE
Add hack to allow updating in memory without locking data file

### DIFF
--- a/include/oks/file.hpp
+++ b/include/oks/file.hpp
@@ -380,6 +380,11 @@ class OksFile {
 
     void lock();
 
+  // Nasty hack to allow code generation on the fly without locking
+  // file. Off by default
+  static void set_nolock_mode(bool nl) {p_nolock_mode = nl;}
+
+
 
       /**
        *   \brief Unlock OKS file.
@@ -729,6 +734,7 @@ class OksFile {
 
 
   private:
+  static bool p_nolock_mode; // Nasty hack mode
 
     std::string p_short_name;  // short path to file
     std::string p_full_name;   // path which is used to open file

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -27,6 +27,9 @@
 
 namespace dunedaq {
 namespace oks {
+  // Nasty hack to allow code generation on the fly without locking
+  // file. Off by default
+  bool OksFile::p_nolock_mode = false;
     //
     // Define XML formats used to store OKS schema and data files
     //
@@ -1008,6 +1011,12 @@ OksFile::get_lock_string(std::string& lock_file_contents) const
 void
 OksFile::lock()
 {
+  if (p_nolock_mode) {
+    // Nasty hack to allow code generation on the fly without locking
+    // file. Just return without locking!
+    return;
+  }
+
   init_lock_name();
 
   if (p_lock != nullptr)


### PR DESCRIPTION
Locking the OKS db files is a problem for generating dal objects on the fly as we do in smart DAQ applications as we will be running several at the same time. Since we don't ever want to save these objects in the file, we need a way to avoid locking the files.