### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(oks VERSION 1.3.1)
+project(oks VERSION 1.3.2)
 
 find_package(daq-cmake REQUIRED)
 

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -152,7 +152,7 @@ PYBIND11_MODULE(_daq_oks_py, m)
     // get_active_schema
     .def("get_active_schema",&OksKernel::get_active_schema)
     // schema_files
-    .def("schema_files",&OksKernel::schema_files)
+    .def("schema_files",&OksKernel::schema_files, py::return_value_policy::reference_internal)
     
     //! create_list_of_upsated_schema_file
     //! get_updated_repository_files


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.