### PR TITLE
Add oks_check_schema application

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ daq_add_python_bindings(*.cpp)
 
 
 daq_add_application(oks_dump oks_dump.cxx LINK_LIBRARIES oks)
+daq_add_application(oks_check_schema oks_check_schema.cxx LINK_LIBRARIES CLI11::CLI11 fmt::fmt oks)
 daq_add_application(oks_git_repository oks_git_repository.cxx LINK_LIBRARIES oks)
 daq_add_application(oks_clone_repository oks_clone_repository.cxx LINK_LIBRARIES oks Boost::program_options)
 daq_add_application(oks_validate_repository oks_validate_repository.cxx LINK_LIBRARIES oks Boost::program_options)

--- a/apps/oks_check_schema.cxx
+++ b/apps/oks_check_schema.cxx
@@ -1,0 +1,79 @@
+/**
+ * @file oks_check_schema.cxx
+ *
+ * Program to do some simple integrity checks on a schema file
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2025.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "CLI/CLI.hpp"
+#include "oks/class.hpp"
+#include "oks/file.hpp"
+#include "oks/kernel.hpp"
+#include "oks/relationship.hpp"
+
+#include <fmt/core.h>
+
+using namespace dunedaq::oks;
+
+
+int main(int argc, char **argv) {
+  enum Exitcode : int {SUCCESS, BADCMD, NOFILE, LOADFAIL, BADRELATIONSHIP};
+
+  CLI::App app{"Check consistency of OKS schema file\n"+
+    fmt::format("Return codes: {} Success, file is OK\n", Exitcode::SUCCESS)+
+    fmt::format("              {} Bad command line\n", Exitcode::BADCMD)+
+    fmt::format("              {} Failed to find file\n", Exitcode::NOFILE)+
+    fmt::format("              {} Failed to load file -- invalid schema\n", Exitcode::LOADFAIL)+
+    fmt::format("              {} File contains relationship to non loaded class\n", Exitcode::BADRELATIONSHIP)
+  };
+
+  std::string filename;
+  app.add_option("-f,--file", filename, "Schema file")
+    ->required();
+
+  CLI11_PARSE(app, argc, argv);
+
+  OksKernel kernel;
+  OksFile* file;
+  try {
+    file = kernel.load_file(filename);
+  }
+  catch (FailedLoadFile& fail) {
+    std::cerr << fail.what() << "\n";
+    return Exitcode::LOADFAIL;
+  }
+  catch (CanNotOpenFile& fail) {
+    std::cerr << fail.what() << "\n";
+    return Exitcode::NOFILE;
+  }
+  catch (std::exception& exc) {
+    std::cerr << exc.what() << "\n";
+    return Exitcode::LOADFAIL;
+  }
+  if (file == nullptr) {
+    return Exitcode::LOADFAIL;
+  }
+
+  for (auto [name, oks_class] : kernel.classes()) {
+    auto relationships = oks_class->direct_relationships();
+    if (relationships != nullptr) {
+      for (auto rel: *relationships) {
+        auto rel_class = rel->get_class_type();
+        if (rel_class == nullptr) {
+          std::cerr << "Error class '" << name
+                    << "' has relationship '" << rel->get_name()
+                    << "' to a class '" << rel->get_type()
+                    << "' that is not loaded\n";
+          return Exitcode::BADRELATIONSHIP;
+        }
+      }
+    }
+    // Could check super-classes but we wouldn't have got past the
+    // load if they referred to a missing class.
+  }
+
+  return 0;
+}

--- a/apps/oks_check_schema.cxx
+++ b/apps/oks_check_schema.cxx
@@ -9,12 +9,14 @@
  */
 
 #include "CLI/CLI.hpp"
+#include "logging/Logging.hpp"
 #include "oks/class.hpp"
 #include "oks/file.hpp"
 #include "oks/kernel.hpp"
 #include "oks/relationship.hpp"
 
 #include <fmt/core.h>
+#include <string>
 
 using namespace dunedaq::oks;
 
@@ -37,23 +39,23 @@ int main(int argc, char **argv) {
   CLI11_PARSE(app, argc, argv);
 
   OksKernel kernel;
-  OksFile* file;
   try {
-    file = kernel.load_file(filename);
+    const auto file = kernel.load_file(filename);
+    if (file == nullptr) {
+      TLOG() << "Failed to load " << filename;
+      return Exitcode::LOADFAIL;
+    }
   }
   catch (FailedLoadFile& fail) {
-    std::cerr << fail.what() << "\n";
+    TLOG() << fail.what() << "\n";
     return Exitcode::LOADFAIL;
   }
   catch (CanNotOpenFile& fail) {
-    std::cerr << fail.what() << "\n";
+    TLOG() << fail.what() << "\n";
     return Exitcode::NOFILE;
   }
   catch (std::exception& exc) {
-    std::cerr << exc.what() << "\n";
-    return Exitcode::LOADFAIL;
-  }
-  if (file == nullptr) {
+    TLOG() << exc.what() << "\n";
     return Exitcode::LOADFAIL;
   }
 
@@ -63,7 +65,7 @@ int main(int argc, char **argv) {
       for (auto rel: *relationships) {
         auto rel_class = rel->get_class_type();
         if (rel_class == nullptr) {
-          std::cerr << "Error class '" << name
+          TLOG() << "Error class '" << name
                     << "' has relationship '" << rel->get_name()
                     << "' to a class '" << rel->get_type()
                     << "' that is not loaded\n";


### PR DESCRIPTION
# Description

Add a simple application, `oks_check_schema`, to check an OKS schema file for dangling references or other errors that make it unload-able by the OKS kernel.

Addresses issue https://github.com/DUNE-DAQ/daq-deliverables/issues/203 

## Testing:
Run the application passing the name of an invalid schema file for example th broken PDS schema from appmodel v4.0.0
```
oks_check_schema -f schema/appmodel/PDS.schema.xml
Loading 11 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/PDS.schema.xml"...
(non-fully-qualified filename was "schema/appmodel/PDS.schema.xml")
 * loading 49 classes from file "/home/gjc/DUNE/packages/confmodel/schema/confmodel/dunedaq.schema.xml"...
 * loading 66 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/application.schema.xml"...
 * loading 33 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/fdmodules.schema.xml"...
Error class 'DaphneApplication' has relationship 'hermes_module_conf' to a class 'HermesModuleConf' that is not loaded
Close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/PDS.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/application.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/fdmodules.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/confmodel/schema/confmodel/dunedaq.schema.xml"...
```
Check the exit code
```
echo $?
4
```

Run again with a valid schema file e.g.wiec.schema.xml
```
oks_check_schema -f schema/appmodel/wiec.schema.xml
Loading 8 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/wiec.schema.xml"...
(non-fully-qualified filename was "schema/appmodel/wiec.schema.xml")
 * loading 49 classes from file "/home/gjc/DUNE/packages/confmodel/schema/confmodel/dunedaq.schema.xml"...
 * loading 66 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/application.schema.xml"...
 * loading 33 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/fdmodules.schema.xml"...
 * loading 10 classes from file "/home/gjc/DUNE/packages/appmodel/schema/appmodel/hermes.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/application.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/fdmodules.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/hermes.schema.xml"...
Close OKS schema "/home/gjc/DUNE/packages/appmodel/schema/appmodel/wiec.schema.xml"...
 * close OKS schema "/home/gjc/DUNE/packages/confmodel/schema/confmodel/dunedaq.schema.xml"..
```
Check that no error are reported and the exit code is 0

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

